### PR TITLE
Add shell script to launch mac development environment

### DIFF
--- a/macStartDeveloping.sh
+++ b/macStartDeveloping.sh
@@ -1,0 +1,17 @@
+export projectDirectory=pwd
+echo "Watching Sass files for changes"
+docker build -t profile-image .
+osascript -e 'tell application "System Events" to tell process "Terminal" to keystroke "t" using command down'
+osascript -e 'tell app "Terminal" to do script " gulp watchSass" in window 1' &
+export sassWatcherPid=$!
+export projectDirectory=$PWD
+export commandStart="tell app \"Terminal\" to do script \"docker run -v "
+export commandEnd=":/usr/src/app profile-image gulp startServer\" in window 1"
+export command=$commandStart$projectDirectory$commandEnd
+osascript -e 'tell application "System Events" to tell process "Terminal" to keystroke "t" using command down'
+osascript -e "$command" &
+export dockerPid=$!
+echo 'sassWatcherPid'
+echo $sassWatcherPid
+echo 'dockerPid'
+echo $dockerPid


### PR DESCRIPTION
Encountered an issue where node-sass has some configurations specific
to the environment the project exists in. There is a conflict with
the Mac OS mounting its directory in the linux server. I am going to
go ahead and commit this file in progress as I need to focus on the
frontend for now. I will be able to fix this problem later using
docker compose.